### PR TITLE
Feature #3 mapper 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,13 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.mapstruct:mapstruct:1.4.2.Final'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'org.mapstruct:mapstruct:1.4.2.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testAnnotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/flab/posttoy/domain/Comment.java
+++ b/src/main/java/com/flab/posttoy/domain/Comment.java
@@ -1,8 +1,11 @@
 package com.flab.posttoy.domain;
 
+import lombok.Builder;
 import lombok.Getter;
 
+// 불변객체를 유지하기 위해 setter 대신 builder
 @Getter
+@Builder
 public class Comment {
     private Long id;
     private Long userId;

--- a/src/main/java/com/flab/posttoy/domain/Post.java
+++ b/src/main/java/com/flab/posttoy/domain/Post.java
@@ -1,10 +1,11 @@
 package com.flab.posttoy.domain;
 
+import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
-
+// 불변객체를 유지하기 위해 setter 대신 builder
 @Getter
+@Builder
 public class Post {
     private Long id;
     private Long userId;

--- a/src/main/java/com/flab/posttoy/domain/User.java
+++ b/src/main/java/com/flab/posttoy/domain/User.java
@@ -1,10 +1,11 @@
 package com.flab.posttoy.domain;
 
+import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
-
+// 불변객체를 유지하기 위해 setter 대신 builder
 @Getter
+@Builder
 public class User {
     private Long id;
     private String username;

--- a/src/main/java/com/flab/posttoy/dto/CommentDTO.java
+++ b/src/main/java/com/flab/posttoy/dto/CommentDTO.java
@@ -1,0 +1,13 @@
+package com.flab.posttoy.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CommentDTO {
+    private Long id;
+    private Long userId;
+    private Long postId;
+    private String content;
+}

--- a/src/main/java/com/flab/posttoy/dto/PostDTO.java
+++ b/src/main/java/com/flab/posttoy/dto/PostDTO.java
@@ -1,0 +1,13 @@
+package com.flab.posttoy.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PostDTO {
+    private Long id;
+    private Long userId;
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/flab/posttoy/dto/UserDTO.java
+++ b/src/main/java/com/flab/posttoy/dto/UserDTO.java
@@ -1,0 +1,12 @@
+package com.flab.posttoy.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserDTO {
+    private Long id;
+    private String username;
+    private String password;
+}

--- a/src/main/java/com/flab/posttoy/dto/mapper/CommentMapper.java
+++ b/src/main/java/com/flab/posttoy/dto/mapper/CommentMapper.java
@@ -1,0 +1,11 @@
+package com.flab.posttoy.dto.mapper;
+
+import com.flab.posttoy.domain.Comment;
+import com.flab.posttoy.dto.CommentDTO;
+import org.mapstruct.Mapper;
+
+// spring 빈으로 등록해준다.
+// Mapper가 자동으로 구현체를 만들어줌
+@Mapper(componentModel = "spring")
+public interface CommentMapper extends GenericMapper <CommentDTO, Comment>{
+}

--- a/src/main/java/com/flab/posttoy/dto/mapper/CommentMapper.java
+++ b/src/main/java/com/flab/posttoy/dto/mapper/CommentMapper.java
@@ -7,5 +7,8 @@ import org.mapstruct.Mapper;
 // spring 빈으로 등록해준다.
 // Mapper가 자동으로 구현체를 만들어줌
 @Mapper(componentModel = "spring")
-public interface CommentMapper extends GenericMapper <CommentDTO, Comment>{
+public interface CommentMapper{
+    Comment toComment(CommentDTO commentDTO);
+
+    CommentDTO toCommentDto(Comment comment);
 }

--- a/src/main/java/com/flab/posttoy/dto/mapper/GenericMapper.java
+++ b/src/main/java/com/flab/posttoy/dto/mapper/GenericMapper.java
@@ -1,0 +1,10 @@
+package com.flab.posttoy.dto.mapper;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValueMappingStrategy;
+
+public interface GenericMapper <D,E>{
+    D toDto(E e);
+    E toEntity(D d);
+}

--- a/src/main/java/com/flab/posttoy/dto/mapper/PostMapper.java
+++ b/src/main/java/com/flab/posttoy/dto/mapper/PostMapper.java
@@ -7,5 +7,7 @@ import org.mapstruct.Mapper;
 // spring 빈으로 등록해준다.
 // Mapper가 자동으로 구현체를 만들어줌
 @Mapper(componentModel = "spring")
-public interface PostMapper extends GenericMapper <PostDTO, Post>{
+public interface PostMapper{
+    Post toPost(PostDTO postDTO);
+    PostDTO toPostDto(Post post);
 }

--- a/src/main/java/com/flab/posttoy/dto/mapper/PostMapper.java
+++ b/src/main/java/com/flab/posttoy/dto/mapper/PostMapper.java
@@ -1,0 +1,11 @@
+package com.flab.posttoy.dto.mapper;
+
+import com.flab.posttoy.domain.Post;
+import com.flab.posttoy.dto.PostDTO;
+import org.mapstruct.Mapper;
+
+// spring 빈으로 등록해준다.
+// Mapper가 자동으로 구현체를 만들어줌
+@Mapper(componentModel = "spring")
+public interface PostMapper extends GenericMapper <PostDTO, Post>{
+}

--- a/src/main/java/com/flab/posttoy/dto/mapper/UserMapper.java
+++ b/src/main/java/com/flab/posttoy/dto/mapper/UserMapper.java
@@ -7,5 +7,9 @@ import org.mapstruct.Mapper;
 // spring 빈으로 등록해준다.
 // Mapper가 자동으로 구현체를 만들어줌
 @Mapper(componentModel = "spring")
-public interface UserMapper extends GenericMapper <UserDTO, User>{
+public interface UserMapper{
+    //to dto
+    UserDTO toUserDto(User user);
+    //to entity
+    User toUser(UserDTO userDTO);
 }

--- a/src/main/java/com/flab/posttoy/dto/mapper/UserMapper.java
+++ b/src/main/java/com/flab/posttoy/dto/mapper/UserMapper.java
@@ -1,0 +1,11 @@
+package com.flab.posttoy.dto.mapper;
+
+import com.flab.posttoy.domain.User;
+import com.flab.posttoy.dto.UserDTO;
+import org.mapstruct.Mapper;
+
+// spring 빈으로 등록해준다.
+// Mapper가 자동으로 구현체를 만들어줌
+@Mapper(componentModel = "spring")
+public interface UserMapper extends GenericMapper <UserDTO, User>{
+}

--- a/src/main/java/com/flab/posttoy/web/dto/CommentDTO.java
+++ b/src/main/java/com/flab/posttoy/web/dto/CommentDTO.java
@@ -1,4 +1,0 @@
-package com.flab.posttoy.web.dto;
-
-public class CommentDTO {
-}

--- a/src/main/java/com/flab/posttoy/web/dto/request/RequestUserDTO.java
+++ b/src/main/java/com/flab/posttoy/web/dto/request/RequestUserDTO.java
@@ -1,0 +1,4 @@
+package com.flab.posttoy.web.dto.request;
+
+public class RequestUserDTO {
+}

--- a/src/main/java/com/flab/posttoy/web/dto/request/mapper/RequestMapper.java
+++ b/src/main/java/com/flab/posttoy/web/dto/request/mapper/RequestMapper.java
@@ -1,0 +1,4 @@
+package com.flab.posttoy.web.dto.request.mapper;
+
+public class RequestMapper {
+}

--- a/src/main/java/com/flab/posttoy/web/dto/response/ResponseUserDTO.java
+++ b/src/main/java/com/flab/posttoy/web/dto/response/ResponseUserDTO.java
@@ -1,0 +1,4 @@
+package com.flab.posttoy.web.dto.response;
+
+public class ResponseUserDTO {
+}

--- a/src/main/java/com/flab/posttoy/web/dto/response/mapper/ResponseMapper.java
+++ b/src/main/java/com/flab/posttoy/web/dto/response/mapper/ResponseMapper.java
@@ -1,0 +1,4 @@
+package com.flab.posttoy.web.dto.response.mapper;
+
+public class ResponseMapper {
+}

--- a/src/test/java/com/flab/posttoy/mapper/MapperTest.java
+++ b/src/test/java/com/flab/posttoy/mapper/MapperTest.java
@@ -1,0 +1,51 @@
+package com.flab.posttoy.mapper;
+
+import com.flab.posttoy.domain.User;
+import com.flab.posttoy.dto.UserDTO;
+import com.flab.posttoy.dto.mapper.UserMapper;
+import com.flab.posttoy.dto.mapper.UserMapperImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class MapperTest {
+
+    @Test
+    @DisplayName("User 엔티티를 DTO로 변환 테스트")
+    void userToDtoMapperTest(){
+        ApplicationContext ac = new AnnotationConfigApplicationContext(UserMapperImpl.class);
+        UserMapper mapper = ac.getBean(UserMapper.class);
+
+        User user = User.builder()
+                .id(1L)
+                .username("hojoon")
+                .password("1234")
+                .build();
+
+        UserDTO userDTO = mapper.toDto(user);
+        assertThat(userDTO.getId()).isEqualTo(1L);
+        assertThat(userDTO.getUsername()).isEqualTo("hojoon");
+        assertThat(userDTO.getPassword()).isEqualTo("1234");
+    }
+
+    @Test
+    @DisplayName("UserDTO를 User로 변환 테스트")
+    void DtoToUserMapperTest(){
+        ApplicationContext ac = new AnnotationConfigApplicationContext(UserMapperImpl.class);
+        UserMapper mapper = ac.getBean(UserMapper.class);
+        UserDTO userDTO = new UserDTO();
+        userDTO.setId(1L);
+        userDTO.setUsername("hojoon");
+        userDTO.setPassword("1234");
+
+        User user = mapper.toEntity(userDTO);
+
+        assertThat(user.getId()).isEqualTo(1L);
+        assertThat(user.getUsername()).isEqualTo("hojoon");
+        assertThat(user.getPassword()).isEqualTo("1234");
+    }
+}

--- a/src/test/java/com/flab/posttoy/mapper/MapperTest.java
+++ b/src/test/java/com/flab/posttoy/mapper/MapperTest.java
@@ -26,7 +26,7 @@ public class MapperTest {
                 .password("1234")
                 .build();
 
-        UserDTO userDTO = mapper.toDto(user);
+        UserDTO userDTO = mapper.toUserDto(user);
         assertThat(userDTO.getId()).isEqualTo(1L);
         assertThat(userDTO.getUsername()).isEqualTo("hojoon");
         assertThat(userDTO.getPassword()).isEqualTo("1234");
@@ -42,7 +42,7 @@ public class MapperTest {
         userDTO.setUsername("hojoon");
         userDTO.setPassword("1234");
 
-        User user = mapper.toEntity(userDTO);
+        User user = mapper.toUser(userDTO);
 
         assertThat(user.getId()).isEqualTo(1L);
         assertThat(user.getUsername()).isEqualTo("hojoon");


### PR DESCRIPTION
## 구현 내용 
Service 와 Repository 계층의 도메인을 분리하기 위한 Mapper 를 구현했습니다. MapStruct르로 구현했습니다.
Service 와 Repository 계층을 위한 DTO, Service 와 Controller 를 위한 DTO 로 패키지를 나눴고 DTO 패키지에 Mapper를 구현했습니다.

## 질문
Mapper를   DTO <-> DTO를 위한 mapper DTO <-> Entity를 위한 mapper를 모든 경우에 따라 구현하게 되는데 이럴 경우 각 계층들이 mapper에 대한 의존성이 많이 늘어 날 것 같습니다. 한번에 이 매퍼들을 묶을수 있나요?

@Mapper 어노테이션을 통해 인터페이스를 자동으로 구현해 주는데 단위 테스트시 mapper 객체를 어떻게 가져와야되나요? 빌드 툴이 gradle로 되어있을땐 인식을하는데 툴을 intellij 로 바꾸면 인식을 못합니다. 

질문들은 commit 에도 써 놓았습니다 !!

## issue
#3 